### PR TITLE
Bug fixes and functionality

### DIFF
--- a/consumerlag.yaml
+++ b/consumerlag.yaml
@@ -11,8 +11,27 @@ authentication_list:
 # Dynatrace tenant
 url_tenant: 'https://zzz00000.live.dynatrace.com'
 
-# Broker address
-bootstrap: 'localhost:9092'
+# kafka-consumer-groups.sh --list command as an array
+# This will be executed as-is
+kafka_consumer_groups_list:
+  - "/opt/isv/tools/kafka/bin/kafka-consumer-groups.sh"
+  - "--bootstrap-server"
+  - "localhost:9092"
+  - "--list"
+  - "--command-config"
+  - "/tmp/kafka-bin-client.prop"
+
+# kafka-consumer-groups.sh --describe command as an array
+# This will be appended with "--group" and each returned Consumer Group from the --list command
+kafka_consumer_groups_describe:
+  - "/opt/isv/tools/kafka/bin/kafka-consumer-groups.sh"
+  - "--bootstrap-server"
+  - "localhost:9092"
+  - "--describe"
+  - "--command-config"
+  - "/tmp/kafka-bin-client.prop"
+# - "--group"  --> This will be handled by the code
+# - group_name --> This will be handled by the code
 
 # Dynatrace Custom Device Unique Name (where we push the metrics)
 custom_device: 'KafkaClusterTest01'
@@ -22,6 +41,9 @@ check_metrics_every_x_loops: 1000
 
 # Enable this for simulating Kafka interaction for local development
 development: False
+
+# Enable this if you want to query Kafka but not interact with Dynatrace
+kafka_only: True
 
 # Enable this for enabling debug output
 debug: True


### PR DESCRIPTION
97842fc Add try_request
This is a requirement for the network calls to Dynatrace

b4936da New kafka-consumer-groups functionality
This release changes from the old method of using 'bootstrap' server.
That approach meant that any user of the library would likely need
to customize the python code in order to get their environment working.

Th new method is to specify the full kafka-consumer-groups.sh commands
for '--list' and '--describe' as an array in consumerlag.yaml.

Another improvement is to allow testing of Kafka interaction without
interaction with Dynatrace.  This allows a user of this library to
test the script against their Kafka cluster in separation from
their Dynatrace environment.  This new flag is called 'kafka_only'
and is set to True in the supplied consumerlag.yaml file.