### PR TITLE
Add split_request functionality

### DIFF
--- a/consumerlag.yaml
+++ b/consumerlag.yaml
@@ -40,10 +40,13 @@ custom_device: 'KafkaClusterTest01'
 check_metrics_every_x_loops: 1000
 
 # Enable this for simulating Kafka interaction for local development
-development: False
+development: True
 
 # Enable this if you want to query Kafka but not interact with Dynatrace
 kafka_only: True
+
+# Aim to be conservative and not too close to actual Dynatrace limit
+send_byte_size_limit: 12000
 
 # Enable this for enabling debug output
 debug: True


### PR DESCRIPTION
This release allows the ability to configure a maximum byte size per request.
The default value will be 10000 bytes unless it is specified as
'send_byte_size_limit' within consumerlag.yaml as an alternate value.

Logging will also explain why and how the splitting is occurring.

See log entries for 'SplitRequest' to see this information.